### PR TITLE
Log database connection errors without exposing details

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -24,7 +24,8 @@ class Database {
                                 $this->username, $this->password);
             $this->conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         } catch(PDOException $exception) {
-            echo "Bağlantı hatası: " . $exception->getMessage();
+            error_log("Database connection failed: " . $exception->getMessage());
+            echo "Bir hata oluştu. Lütfen daha sonra tekrar deneyiniz.";
         }
         
         return $this->conn;


### PR DESCRIPTION
## Summary
- Replace direct database connection error output with server-side logging
- Return a generic error message to avoid leaking sensitive details

## Testing
- `php -l config/database.php`


------
https://chatgpt.com/codex/tasks/task_e_68a41ebbb860832aac9c3a7670feaebd